### PR TITLE
tests(fixtures) update fixtures to 0.14.0 release

### DIFF
--- a/spec/01-api_spec.lua
+++ b/spec/01-api_spec.lua
@@ -21,7 +21,9 @@ describe("Plugin: prometheus (API)",function()
       helpers.stop_kong()
     end)
 
-    it("prometheus plugin cannot be configured", function()
+    -- skipping since Kong always injected a `prometheus_metrics` shm when
+    -- prometheus plugin is loaded into memory
+    pending("prometheus plugin cannot be configured", function()
       local res = assert(admin_client:send {
         method  = "POST",
         path    = "/plugins",

--- a/spec/fixtures/prometheus/invalid_nginx.template
+++ b/spec/fixtures/prometheus/invalid_nginx.template
@@ -42,8 +42,9 @@ http {
     lua_max_running_timers 4096;
     lua_max_pending_timers 16384;
     lua_shared_dict kong                5m;
-    lua_shared_dict kong_cache          ${{MEM_CACHE_SIZE}};
+    lua_shared_dict kong_db_cache       ${{MEM_CACHE_SIZE}};
     lua_shared_dict kong_db_cache_miss 12m;
+    lua_shared_dict kong_locks          8m;
     lua_shared_dict kong_process_events 5m;
     lua_shared_dict kong_cluster_events 5m;
     lua_shared_dict kong_healthchecks   5m;
@@ -57,20 +58,25 @@ http {
     lua_ssl_verify_depth ${{LUA_SSL_VERIFY_DEPTH}};
 > end
 
+# injected nginx_http_* directives
+> for _, el in ipairs(nginx_http_directives)  do
+    $(el.name) $(el.value);
+> end
+
     init_by_lua_block {
-        kong = require 'kong'
-        kong.init()
+        Kong = require 'kong'
+        Kong.init()
     }
 
     init_worker_by_lua_block {
-        kong.init_worker()
+        Kong.init_worker()
     }
 
 > if #proxy_listeners > 0 then
     upstream kong_upstream {
         server 0.0.0.1;
         balancer_by_lua_block {
-            kong.balancer()
+            Kong.balancer()
         }
         keepalive ${{UPSTREAM_KEEPALIVE}};
     }
@@ -92,7 +98,7 @@ http {
         ssl_certificate_key ${{SSL_CERT_KEY}};
         ssl_protocols TLSv1.1 TLSv1.2;
         ssl_certificate_by_lua_block {
-            kong.ssl_certificate()
+            Kong.ssl_certificate()
         }
 > end
 
@@ -102,7 +108,15 @@ http {
         set_real_ip_from   $(trusted_ips[i]);
 > end
 
+    # injected nginx_proxy_* directives
+> for _, el in ipairs(nginx_proxy_directives)  do
+        $(el.name) $(el.value);
+> end
+
         location / {
+            default_type '';
+
+            set $ctx_ref                     '';
             set $upstream_host               '';
             set $upstream_upgrade            '';
             set $upstream_connection         '';
@@ -114,11 +128,11 @@ http {
             set $upstream_x_forwarded_port   '';
 
             rewrite_by_lua_block {
-                kong.rewrite()
+                Kong.rewrite()
             }
 
             access_by_lua_block {
-                kong.access()
+                Kong.access()
             }
 
             proxy_http_version 1.1;
@@ -136,22 +150,36 @@ http {
             proxy_pass         $upstream_scheme://kong_upstream$upstream_uri;
 
             header_filter_by_lua_block {
-                kong.header_filter()
+                Kong.header_filter()
             }
 
             body_filter_by_lua_block {
-                kong.body_filter()
+                Kong.body_filter()
             }
 
             log_by_lua_block {
-                kong.log()
+                Kong.log()
             }
         }
 
         location = /kong_error_handler {
             internal;
+            uninitialized_variable_warn off;
+
             content_by_lua_block {
-                kong.handle_error()
+                Kong.handle_error()
+            }
+
+            header_filter_by_lua_block {
+                Kong.header_filter()
+            }
+
+            body_filter_by_lua_block {
+                Kong.body_filter()
+            }
+
+            log_by_lua_block {
+                Kong.log()
             }
         }
     }
@@ -175,10 +203,15 @@ http {
         ssl_protocols TLSv1.1 TLSv1.2;
 > end
 
+    # injected nginx_admin_* directives
+> for _, el in ipairs(nginx_admin_directives)  do
+        $(el.name) $(el.value);
+> end
+
         location / {
             default_type application/json;
             content_by_lua_block {
-                kong.serve_admin_api()
+                Kong.serve_admin_api()
             }
         }
 

--- a/spec/fixtures/prometheus/valid_nginx.template
+++ b/spec/fixtures/prometheus/valid_nginx.template
@@ -42,12 +42,12 @@ http {
     lua_max_running_timers 4096;
     lua_max_pending_timers 16384;
     lua_shared_dict kong                5m;
-    lua_shared_dict kong_cache          ${{MEM_CACHE_SIZE}};
+    lua_shared_dict kong_db_cache       ${{MEM_CACHE_SIZE}};
     lua_shared_dict kong_db_cache_miss 12m;
+    lua_shared_dict kong_locks          8m;
     lua_shared_dict kong_process_events 5m;
     lua_shared_dict kong_cluster_events 5m;
     lua_shared_dict kong_healthchecks   5m;
-    lua_shared_dict prometheus_metrics  2m;
     lua_shared_dict kong_rate_limiting_counters 12m;
 > if database == "cassandra" then
     lua_shared_dict kong_cassandra      5m;
@@ -58,20 +58,25 @@ http {
     lua_ssl_verify_depth ${{LUA_SSL_VERIFY_DEPTH}};
 > end
 
+# injected nginx_http_* directives
+> for _, el in ipairs(nginx_http_directives)  do
+    $(el.name) $(el.value);
+> end
+
     init_by_lua_block {
-        kong = require 'kong'
-        kong.init()
+        Kong = require 'kong'
+        Kong.init()
     }
 
     init_worker_by_lua_block {
-        kong.init_worker()
+        Kong.init_worker()
     }
 
 > if #proxy_listeners > 0 then
     upstream kong_upstream {
         server 0.0.0.1;
         balancer_by_lua_block {
-            kong.balancer()
+            Kong.balancer()
         }
         keepalive ${{UPSTREAM_KEEPALIVE}};
     }
@@ -93,7 +98,7 @@ http {
         ssl_certificate_key ${{SSL_CERT_KEY}};
         ssl_protocols TLSv1.1 TLSv1.2;
         ssl_certificate_by_lua_block {
-            kong.ssl_certificate()
+            Kong.ssl_certificate()
         }
 > end
 
@@ -103,7 +108,15 @@ http {
         set_real_ip_from   $(trusted_ips[i]);
 > end
 
+    # injected nginx_proxy_* directives
+> for _, el in ipairs(nginx_proxy_directives)  do
+        $(el.name) $(el.value);
+> end
+
         location / {
+            default_type '';
+
+            set $ctx_ref                     '';
             set $upstream_host               '';
             set $upstream_upgrade            '';
             set $upstream_connection         '';
@@ -115,11 +128,11 @@ http {
             set $upstream_x_forwarded_port   '';
 
             rewrite_by_lua_block {
-                kong.rewrite()
+                Kong.rewrite()
             }
 
             access_by_lua_block {
-                kong.access()
+                Kong.access()
             }
 
             proxy_http_version 1.1;
@@ -137,22 +150,36 @@ http {
             proxy_pass         $upstream_scheme://kong_upstream$upstream_uri;
 
             header_filter_by_lua_block {
-                kong.header_filter()
+                Kong.header_filter()
             }
 
             body_filter_by_lua_block {
-                kong.body_filter()
+                Kong.body_filter()
             }
 
             log_by_lua_block {
-                kong.log()
+                Kong.log()
             }
         }
 
         location = /kong_error_handler {
             internal;
+            uninitialized_variable_warn off;
+
             content_by_lua_block {
-                kong.handle_error()
+                Kong.handle_error()
+            }
+
+            header_filter_by_lua_block {
+                Kong.header_filter()
+            }
+
+            body_filter_by_lua_block {
+                Kong.body_filter()
+            }
+
+            log_by_lua_block {
+                Kong.log()
             }
         }
     }
@@ -176,10 +203,15 @@ http {
         ssl_protocols TLSv1.1 TLSv1.2;
 > end
 
+    # injected nginx_admin_* directives
+> for _, el in ipairs(nginx_admin_directives)  do
+        $(el.name) $(el.value);
+> end
+
         location / {
             default_type application/json;
             content_by_lua_block {
-                kong.serve_admin_api()
+                Kong.serve_admin_api()
             }
         }
 
@@ -383,22 +415,22 @@ http {
         }
     }
 
-	server {
-	    server_name kong_prometheus_exporter;
-	    listen 0.0.0.0:9542;
+    server {
+       server_name kong_prometheus_exporter;
+       listen 0.0.0.0:9542;
 
-	    location / {
-	        default_type text/plain;
-	        content_by_lua_block {
-	            local serve = require "kong.plugins.prometheus.serve"
-	            serve.prometheus_server()
-	        }
-	    }
+       location / {
+           default_type text/plain;
+           content_by_lua_block {
+               local serve = require "kong.plugins.prometheus.serve"
+               serve.prometheus_server()
+           }
+       }
 
-	    location /nginx_status {
-	        internal;
-	        access_log off;
-	        stub_status;
-	    }
-	}
+       location /nginx_status {
+           internal;
+           access_log off;
+           stub_status;
+       }
+    }
 }


### PR DESCRIPTION
With 0.14.0, some shared dicts are made mandatory and Kong's nginx
template introduced a few breaking changes.

Also, 0.14.0 always injects the `prometheus_metrics` shm if prometheus plugin
is enabled and hence one test is marked as pending.