### PR TITLE
fix: avoid recording duplicate metrics

### DIFF
--- a/spec/02-access_spec.lua
+++ b/spec/02-access_spec.lua
@@ -57,7 +57,6 @@ describe("Plugin: prometheus (access)", function()
       path    = "/metrics",
     })
     local body = assert.res_status(200, res)
-    assert.matches('kong_http_status_total{code="200"} 1', body, nil, true)
     assert.matches('kong_http_status{code="200",service="mock-service"} 1', body, nil, true)
 
     ngx.sleep(1)
@@ -75,7 +74,6 @@ describe("Plugin: prometheus (access)", function()
       path    = "/metrics",
     })
     local body = assert.res_status(200, res)
-    assert.matches('kong_http_status_total{code="400"} 1', body, nil, true)
     assert.matches('kong_http_status{code="400",service="mock-service"} 1', body, nil, true)
   end)
 end)

--- a/spec/03-custom-serve_spec.lua
+++ b/spec/03-custom-serve_spec.lua
@@ -55,7 +55,6 @@ describe("Plugin: prometheus (custom server)",function()
     	  path    = "/metrics",
     	})
     	local body = assert.res_status(200, res)
-    	assert.matches('kong_http_status_total{code="200"} 1', body, nil, true)
     	assert.matches('kong_http_status{code="200",service="mock-service"} 1', body, nil, true)
     end)
   end)


### PR DESCRIPTION
Problem:
All metrics are recorded by incrementing counters in a shared dictionary.
As the number of metrics increase, so does the contention among Nginx
worker process to increase those counters increases leading to higher
CPU utilization and potentially will result in a drop in peak RPS.
This also affects the collection phase of metrics where the shared
dictionary needs to be locked for a longer time.

Solution:
Since half of the metrics being recorded are duplicate anyways, those
metrics can be dropped. This doesn't result in any loss functionally
since these metrics can be easily in Prometheus.