### PR TITLE
feat(prometheus) update to the new kong db

### DIFF
--- a/kong/plugins/prometheus/api.lua
+++ b/kong/plugins/prometheus/api.lua
@@ -1,10 +1,15 @@
 local prometheus = require "kong.plugins.prometheus.exporter"
 
+local consumers_schema = kong.db.consumers.schema
 
 return {
+
   ["/metrics"] = {
-    GET = function(self, dao_factory) -- luacheck: ignore 212
-      prometheus.collect()
-    end,
+    schema = consumers_schema, -- not used, could be any schema
+    methods = {
+      GET = function()
+        prometheus.collect()
+      end,
+    },
   },
 }

--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -29,7 +29,7 @@ function PrometheusHandler:log(conf) -- luacheck: ignore 212
   local message = basic_serializer.serialize(ngx)
   local ok, err = ngx.timer.at(0, log, message)
   if not ok then
-    ngx.log(ngx.ERR, "failed to create timer: ", err)
+    kong.log.ERR("failed to create timer: ", err)
   end
 end
 

--- a/kong/plugins/prometheus/schema.lua
+++ b/kong/plugins/prometheus/schema.lua
@@ -1,13 +1,21 @@
-local Errors = require "kong.dao.errors"
+local typedefs = require "kong.db.schema.typedefs"
+
+local function validate_shared_dict()
+  if not ngx.shared.prometheus_metrics then
+    return nil,
+           "ngx shared dict 'prometheus_metrics' not found"
+  end
+  return true
+end
 
 
 return {
-  fields = {},
-  self_check = function(schema, plugin_t, dao, is_update) -- luacheck: ignore 212
-    if not ngx.shared.prometheus_metrics then
-      return false,
-             Errors.schema "ngx shared dict 'prometheus_metrics' not found"
-    end
-    return true
-  end,
+  name = "prometheus",
+  fields = {
+    { config = {
+        type = "record",
+        fields = {},
+        custom_validator = validate_shared_dict,
+    }, },
+  },
 }

--- a/kong/plugins/prometheus/serve.lua
+++ b/kong/plugins/prometheus/serve.lua
@@ -26,8 +26,7 @@ end
 
 
 app:match("/", function()
-  ngx.say("Kong Prometheus exporter, visit /metrics")
-  ngx.exit(200)
+  kong.response.exit(200, "Kong Prometheus exporter, visit /metrics")
 end)
 
 


### PR DESCRIPTION
This PR changes the plugin to make it compatible with the current next branch in kong.

* It changes the schema.lua to the new plugin schema syntax
* It translates several ngx.* calls to kong.* calls, using the new PDK (not all of them are translateable just yet).
* The `prometheus/prometheus.lua` vendored dependency has been left untouched.
* The api.lua file has also been updated.