### PR TITLE
fix: skip recording metrics when no service is matched

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -46,9 +46,13 @@ local function log(message)
     return
   end
 
-  local service_name = message.service and message.service.name or
-                       message.service.host
-  service_name = service_name or ""
+  local service_name
+  if message and message.service then
+    service_name = message.service.name or message.service.host
+  else
+    -- do not record any stats if the service is not present
+    return
+  end
 
   metrics.status:inc(1, { message.response.status, service_name })
 


### PR DESCRIPTION
If Kong has an error or if Kong is returning
a 404 when no Route is matches, the plugin will
be executed and no service will be matched.

This change avoids recording those metrics and a potential
nil dereference, resulting in noise in logs.

Cases when plugin is executed when Kong has an error
or other cases should be recorded by the plugin
but is out of scope for this fix.