### PR TITLE
fix: skip sending status code after body is sent

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -121,7 +121,6 @@ local function collect()
   end
 
   prometheus:collect()
-  return kong.response.exit(200)
 end
 
 


### PR DESCRIPTION
This commit fixes a bug where the plugin tries to send HTTP status code
after the response body is sent for `/metrics` endpoint.

This resulted in error logs in Kong.
A test has been added to ensure that no error logs are generated when
`/metrics` is scraped by Prometheus.

Another test has been added to ensure that the response body only
contains either metrics or comments describing the metrics.
This test is added to catch regression for
https://github.com/Kong/kong/pull/4077, where Kong injected HTML
generated by the default Lapis handler.

Fixes #32