### PR TITLE
feat(prometheus) replace kong.tools.responses with raw ngx methods

### DIFF
--- a/kong/plugins/prometheus/serve.lua
+++ b/kong/plugins/prometheus/serve.lua
@@ -1,6 +1,5 @@
 local lapis = require "lapis"
 local prometheus = require "kong.plugins.prometheus.exporter"
-local responses = require "kong.tools.responses"
 
 
 local app = lapis.Application()
@@ -21,7 +20,11 @@ end
 
 
 app.handle_404 = function(self) -- luacheck: ignore 212
-  return responses.send_HTTP_NOT_FOUND()
+  local body = '{"message":"Not found"}'
+  ngx.header["Content-Type"] = "application/json; charset=utf-8"
+  ngx.header["Content-Length"] = #body + 1
+  ngx.say(body)
+  ngx.exit(404)
 end
 
 

--- a/kong/plugins/prometheus/serve.lua
+++ b/kong/plugins/prometheus/serve.lua
@@ -21,10 +21,10 @@ end
 
 app.handle_404 = function(self) -- luacheck: ignore 212
   local body = '{"message":"Not found"}'
+  ngx.status = 404
   ngx.header["Content-Type"] = "application/json; charset=utf-8"
   ngx.header["Content-Length"] = #body + 1
   ngx.say(body)
-  ngx.exit(404)
 end
 
 

--- a/spec/03-custom-serve_spec.lua
+++ b/spec/03-custom-serve_spec.lua
@@ -58,5 +58,14 @@ describe("Plugin: prometheus (custom server)",function()
       local body = assert.res_status(200, res)
       assert.matches('kong_http_status{code="200",service="mock-service"} 1', body, nil, true)
     end)
+    it("custom port returns 404 for anything other than /metrics", function()
+      local client = helpers.http_client("127.0.0.1", 9542)
+      res = assert(client:send {
+        method  = "GET",
+        path    = "/does-not-exists",
+      })
+      local body = assert.res_status(404, res)
+      assert.matches('{"message":"Not found"}', body, nil, true)
+    end)
   end)
 end)


### PR DESCRIPTION
`kong.tools.responses` is going to be removed from kong so I'm removing it from this plugin.

It didn't look like the `kong` global variable was available in the two files I modified, so I have used `ngx` methods instead.