### PR TITLE
WIP: Export Prometheus metrics from Streaming module

### DIFF
--- a/kong/plugins/prometheus/collectors/base.lua
+++ b/kong/plugins/prometheus/collectors/base.lua
@@ -1,0 +1,14 @@
+local Object = require "kong.vendor.classic"
+
+local BaseCollector = Object:extend()
+
+function BaseCollector:new()
+end
+
+function BaseCollector:record(request)
+end
+
+function BaseCollector:collect()
+end
+
+return BaseCollector

--- a/kong/plugins/prometheus/collectors/http.lua
+++ b/kong/plugins/prometheus/collectors/http.lua
@@ -1,0 +1,62 @@
+local DEFAULT_BUCKETS = { 1, 2, 5, 7, 10, 15, 20, 25, 30, 40, 50, 60, 70,
+    80, 90, 100, 200, 300, 400, 500, 1000,
+    2000, 5000, 10000, 30000, 60000 }
+
+
+local BaseCollector = require "kong.plugins.prometheus.collectors.base"
+
+local HttpMetrics = BaseCollector:extend()
+
+function HttpMetrics:new(prometheus)
+
+    -- per service
+    self.status = prometheus:counter("http_status",
+        "HTTP status codes per service in Kong",
+        {"code", "service"})
+    self.latency = prometheus:histogram("latency",
+        "Latency added by Kong, total request time and upstream latency for each service in Kong",
+        {"type", "service"},
+        DEFAULT_BUCKETS) -- TODO make this configurable
+    self.bandwidth = prometheus:counter("bandwidth",
+        "Total bandwidth in bytes consumed per service in Kong",
+        {"type", "service"})
+end
+
+function HttpMetrics:record(message)
+    local service_name
+    if message and message.service then
+        service_name = message.service.name or message.service.host
+    else
+        -- do not record any stats if the service is not present
+        return
+    end
+
+    self.status:inc(1, { message.response.status, service_name })
+
+    local request_size = tonumber(message.request.size)
+    if request_size and request_size > 0 then
+        self.bandwidth:inc(request_size, { "ingress", service_name })
+    end
+
+    local response_size = tonumber(message.response.size)
+    if response_size and response_size > 0 then
+        self.bandwidth:inc(response_size, { "egress", service_name })
+    end
+
+    local request_latency = message.latencies.request
+    if request_latency and request_latency >= 0 then
+        self.latency:observe(request_latency, { "request", service_name })
+    end
+
+    local upstream_latency = message.latencies.proxy
+    if upstream_latency ~= nil and upstream_latency >= 0 then
+        self.latency:observe(upstream_latency, {"upstream", service_name })
+    end
+
+    local kong_proxy_latency = message.latencies.kong
+    if kong_proxy_latency ~= nil and kong_proxy_latency >= 0 then
+        self.latency:observe(kong_proxy_latency, { "kong", service_name })
+    end
+end
+
+return HttpMetrics

--- a/kong/plugins/prometheus/collectors/kong.lua
+++ b/kong/plugins/prometheus/collectors/kong.lua
@@ -1,0 +1,27 @@
+local BaseCollector = require "kong.plugins.prometheus.collectors.base"
+
+local KongMetrics = BaseCollector:extend()
+
+function KongMetrics:new(prometheus)
+    -- across all services
+
+    self.db_reachable = prometheus:gauge("datastore_reachable",
+        "Datastore reachable from Kong, 0 is unreachable")
+end
+
+function KongMetrics:collect()
+    -- update Guages in here
+
+    -- db reachable?
+    local ok, err = kong.db.connector:connect()
+    if ok then
+        self.db_reachable:set(1)
+
+    else
+        self.db_reachable:set(0)
+        kong.log.err("prometheus: failed to reach database while processing",
+            "/metrics endpoint: ", err)
+    end
+end
+
+return KongMetrics

--- a/kong/plugins/prometheus/collectors/nginx.lua
+++ b/kong/plugins/prometheus/collectors/nginx.lua
@@ -1,0 +1,39 @@
+local find = string.find
+local select = select
+
+local BaseCollector = require "kong.plugins.prometheus.collectors.base"
+
+local NginxMetrics = BaseCollector:extend()
+
+function NginxMetrics:new(prometheus)
+
+    -- across all services
+    self.connections = prometheus:gauge("nginx_connections",
+        "Number of NGINX connections",
+        {"state"})
+end
+
+function NginxMetrics:collect()
+    -- update Guages in here
+
+    local r = ngx.location.capture "/nginx_status"
+
+    if r.status ~= 200 then
+        kong.log.warn("prometheus: failed to retrieve /nginx_status ",
+            "while processing /metrics endpoint")
+
+    else
+        local accepted, handled, total = select(3, find(r.body,
+            "accepts handled requests\n (%d*) (%d*) (%d*)"))
+        self.connections:set(accepted, { "accepted" })
+        self.connections:set(handled, { "handled" })
+        self.connections:set(total, { "total" })
+    end
+
+    self.connections:set(ngx.var.connections_active, { "active" })
+    self.connections:set(ngx.var.connections_reading, { "reading" })
+    self.connections:set(ngx.var.connections_writing, { "writing" })
+    self.connections:set(ngx.var.connections_waiting, { "waiting" })
+end
+
+return NginxMetrics

--- a/kong/plugins/prometheus/collectors/stream.lua
+++ b/kong/plugins/prometheus/collectors/stream.lua
@@ -1,0 +1,33 @@
+local BaseCollector = require "kong.plugins.prometheus.collectors.base"
+
+local StreamMetrics = BaseCollector:extend()
+
+function StreamMetrics:new(prometheus)
+    -- per service
+
+    self.bandwidth = prometheus:counter("bandwidth",
+        "Total bandwidth in bytes consumed per service in Kong",
+        {"type", "service"})
+end
+
+function StreamMetrics:record(message)
+    local service_name
+    if message and message.service then
+        service_name = message.service.name or message.service.host
+    else
+        -- do not record any stats if the service is not present
+        return
+    end
+
+    local request_size = message.request and message.request.size and tonumber(message.request.size) or 0
+    if request_size and request_size > 0 then
+        self.bandwidth:inc(request_size, { "ingress", service_name })
+    end
+
+    local response_size = message.response and message.response.size and tonumber(message.response.size) or 0
+    if response_size and response_size > 0 then
+        self.bandwidth:inc(response_size, { "egress", service_name })
+    end
+end
+
+return StreamMetrics

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -1,131 +1,69 @@
-local find = string.find
-local select = select
-
-local DEFAULT_BUCKETS = { 1, 2, 5, 7, 10, 15, 20, 25, 30, 40, 50, 60, 70,
-                          80, 90, 100, 200, 300, 400, 500, 1000,
-                          2000, 5000, 10000, 30000, 60000 }
-local metrics = {}
 local prometheus
-
+local collectors = {}
+local exporter
 
 local function init()
   local shm = "prometheus_metrics"
-  if not ngx.shared.prometheus_metrics then
-    kong.log.err("prometheus: ngx shared dict 'prometheus_metrics' not found")
+  if not ngx.shared[shm] then
+    kong.log.err("prometheus: ngx shared dict '" .. shm .. "' not found")
     return
   end
 
   prometheus = require("kong.plugins.prometheus.prometheus").init(shm, "kong_")
 
-  -- across all services
-  metrics.connections = prometheus:gauge("nginx_http_current_connections",
-                                         "Number of HTTP connections",
-                                         {"state"})
-  metrics.db_reachable = prometheus:gauge("datastore_reachable",
-                                          "Datastore reachable from Kong, 0 is unreachable")
-
-  -- per service
-  metrics.status = prometheus:counter("http_status",
-                                      "HTTP status codes per service in Kong",
-                                      {"code", "service"})
-  metrics.latency = prometheus:histogram("latency",
-                                         "Latency added by Kong, total request time and upstream latency for each service in Kong",
-                                         {"type", "service"},
-                                         DEFAULT_BUCKETS) -- TODO make this configurable
-  metrics.bandwidth = prometheus:counter("bandwidth",
-                                         "Total bandwidth in bytes consumed per service in Kong",
-                                         {"type", "service"})
+  if ngx.config.subsystem == "stream" then
+    collectors = {
+      require("kong.plugins.prometheus.collectors.stream").new(prometheus)
+    }
+    exporter = require("kong.plugins.prometheus.exporters.stream")
+  elseif ngx.config.subsystem == "http" then
+    collectors = {
+      require("kong.plugins.prometheus.collectors.http").new(prometheus),
+      require("kong.plugins.prometheus.collectors.kong").new(prometheus),
+      require("kong.plugins.prometheus.collectors.nginx").new(prometheus)
+    }
+    exporter = require("kong.plugins.prometheus.exporters.http")
+  end
 end
 
-
-local function log(message)
-  if not metrics then
+local function record(request)
+  if not prometheus then
     kong.log.err("prometheus: can not log metrics because of an initialization "
-                 .. "error, please make sure that you've declared "
-                 .. "'prometheus_metrics' shared dict in your nginx template")
+            .. "error, please make sure that you've declared "
+            .. "'" .. shm .. "' shared dict in your nginx template")
     return
   end
 
-  local service_name
-  if message and message.service then
-    service_name = message.service.name or message.service.host
-  else
-    -- do not record any stats if the service is not present
-    return
-  end
-
-  metrics.status:inc(1, { message.response.status, service_name })
-
-  local request_size = tonumber(message.request.size)
-  if request_size and request_size > 0 then
-    metrics.bandwidth:inc(request_size, { "ingress", service_name })
-  end
-
-  local response_size = tonumber(message.response.size)
-  if response_size and response_size > 0 then
-    metrics.bandwidth:inc(response_size, { "egress", service_name })
-  end
-
-  local request_latency = message.latencies.request
-  if request_latency and request_latency >= 0 then
-    metrics.latency:observe(request_latency, { "request", service_name })
-  end
-
-  local upstream_latency = message.latencies.proxy
-  if upstream_latency ~= nil and upstream_latency >= 0 then
-    metrics.latency:observe(upstream_latency, {"upstream", service_name })
-  end
-
-  local kong_proxy_latency = message.latencies.kong
-  if kong_proxy_latency ~= nil and kong_proxy_latency >= 0 then
-    metrics.latency:observe(kong_proxy_latency, { "kong", service_name })
+  for i in ipairs(collectors) do
+    collectors[i].record(request)
   end
 end
 
-
-local function collect()
-  if not prometheus or not metrics then
+--- At the moment, Lua code running in the context of HTTP module cannot share
+-- any state with Lua code running in the context of Streaming module
+-- (even through shared memory).
+-- That's why we're forced to have 2 separate endpoints with Prometheus metrics:
+-- one for HTTP module and another for Streaming module.
+-- However, we don't want our users to start depending on it -
+-- from their perspective there should be a single Prometheus endpoint.
+-- To achieve this, Prometheus endpoint of HTTP module will be making
+-- a sub-request to the Prometheus endpoint of Streaming module under the hood.
+local function export(opts)
+  if not prometheus then
     kong.log.err("prometheus: plugin is not initialized, please make sure ",
-                 " 'prometheus_metrics' shared dict is present in nginx template")
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
+      " '" .. shm .. "' shared dict is present in nginx template")
+    return exporter.server_error()
   end
 
-  local r = ngx.location.capture "/nginx_status"
-
-  if r.status ~= 200 then
-    kong.log.warn("prometheus: failed to retrieve /nginx_status ",
-                  "while processing /metrics endpoint")
-
-  else
-    local accepted, handled, total = select(3, find(r.body,
-                                            "accepts handled requests\n (%d*) (%d*) (%d*)"))
-    metrics.connections:set(accepted, { "accepted" })
-    metrics.connections:set(handled, { "handled" })
-    metrics.connections:set(total, { "total" })
+  for i in ipairs(collectors) do
+    collectors[i].collect()
   end
 
-  metrics.connections:set(ngx.var.connections_active, { "active" })
-  metrics.connections:set(ngx.var.connections_reading, { "reading" })
-  metrics.connections:set(ngx.var.connections_writing, { "writing" })
-  metrics.connections:set(ngx.var.connections_waiting, { "waiting" })
-
-  -- db reachable?
-  local ok, err = kong.db.connector:connect()
-  if ok then
-    metrics.db_reachable:set(1)
-
-  else
-    metrics.db_reachable:set(0)
-    kong.log.err("prometheus: failed to reach database while processing",
-                 "/metrics endpoint: ", err)
-  end
-
-  prometheus:collect()
+  exporter.export(prometheus, opts)
 end
-
 
 return {
   init    = init,
-  log     = log,
-  collect = collect,
+  log     = record,
+  collect = export
 }

--- a/kong/plugins/prometheus/exporters/http.lua
+++ b/kong/plugins/prometheus/exporters/http.lua
@@ -1,0 +1,54 @@
+local function export(prometheus, opts)
+    prometheus:collect{handler=function(output)
+        ngx.header.content_type = "text/plain"
+        ngx.print(output)
+    end}
+
+    local opts = opts or {}
+    local modules = opts.modules or {}
+    local stream = modules.stream or {}
+    if stream and stream.port then
+        local http = require "resty.http"
+
+        local httpc = http.new()
+        httpc:set_timeout(stream.timeout or 30000)
+        local host = stream.host or "localhost"
+        local port = stream.port
+        local ok, err = httpc:connect(host, port)
+        if not ok then
+            kong.log.err("failed to connect to ", host, ":", tostring(port), ": ", err)
+            return false
+        end
+
+        local res, err = httpc:request({method = "GET", path = "/metrics"})
+        if not res then
+            kong.log.err("failed request to ", host, ":", tostring(port), ": ", err)
+            httpc:set_keepalive(false)
+            return false
+        end
+
+        local body, err = res:read_body()
+        if not body then
+            kong.log.err("no response body from ", host, ":", tostring(port), ": ", err)
+            httpc:set_keepalive(false)
+            return false
+        end
+
+        ok, err = httpc:set_keepalive(false)
+        if not ok then
+            kong.log.err("failed keepalive for ", host, ":", tostring(port), ": ", err)
+        end
+
+        ngx.say()
+        ngx.say(body)
+    end
+end
+
+local function server_error()
+    kong.response.exit(500, { message = "An unexpected error occurred" })
+end
+
+return {
+    export       = export,
+    server_error = server_error,
+}

--- a/kong/plugins/prometheus/exporters/stream.lua
+++ b/kong/plugins/prometheus/exporters/stream.lua
@@ -1,0 +1,38 @@
+local function consume_request()
+    local sock = assert(ngx.req.socket(true))
+    repeat
+        local data = sock:receive()  -- read a line from downstream
+    until data
+end
+
+local function export(prometheus, opts)
+    consume_request()
+
+    prometheus:collect{handler=function(output)
+        -- compute the value for `Content-Length` header
+        local len=0
+        for _, line in ipairs(output) do
+            len = len + #line
+        end
+        len = len + 1
+
+        -- at the moment, we only expect internal usage of that endpoint,
+        -- that's why we don't parse the request and assume usage HTTP/1.1
+        ngx.say("HTTP/1.1 200 OK")
+        ngx.say("Content-Type: text/plain; charset=UTF-8")
+        ngx.say("Content-Length: " .. len)
+        ngx.say("Connection: close")
+        ngx.say()
+        ngx.say(output)
+    end}
+end
+
+local function server_error()
+    ngx.say("HTTP/1.1 500 Internal Server Error")
+    ngx.say("Connection: close")
+end
+
+return {
+    export       = export,
+    server_error = server_error,
+}

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -493,8 +493,12 @@ end
 -- This function should be used to expose the metrics on a separate HTTP page.
 -- It will get the metrics from the dictionary, sort them, and expose them
 -- aling with TYPE and HELP comments.
-function Prometheus:collect()
-  ngx.header.content_type = "text/plain"
+function Prometheus:collect(opts)
+  local opts = opts or {}
+  local handler = opts.handler or function(output)
+    ngx.header.content_type = "text/plain"
+    ngx.print(output)
+  end
   if not self.initialized then
     ngx.log(ngx.ERR, "Prometheus module has not been initialized")
     return
@@ -531,7 +535,7 @@ function Prometheus:collect()
       self:log_error("Error getting '", key, "': ", err)
     end
   end
-  ngx.print(output)
+  handler(output)
 end
 
 return Prometheus


### PR DESCRIPTION
At the moment, Lua code running in the context of HTTP module cannot share
any state with Lua code running in the context of Streaming module
(even through shared memory).

That's why we're forced to have 2 separate endpoints with Prometheus metrics:
one for HTTP module and another for Streaming module.

However, we don't want our users to start depending on it -
from their perspective there should be a single Prometheus endpoint.

To achieve this, Prometheus endpoint of HTTP module will be making
a sub-request to the Prometheus endpoint of Streaming module under the hood.