### PR TITLE
fix(handler) replace :new with :init_worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - [0.2.0](#020---20180924)
 - [0.1.0](#010---20180615)
 
+##  [0.4.1] - 2019/07/31
+
+- Fix issue where the plugin's shared dictionary would not be properly
+initialized
+
 ##  [0.4.0] - 2019/06/05
 
 - Remove BasePlugin inheritance (not needed anymore)

--- a/kong-prometheus-plugin-0.4.1-1.rockspec
+++ b/kong-prometheus-plugin-0.4.1-1.rockspec
@@ -1,9 +1,9 @@
 package = "kong-prometheus-plugin"
-version = "0.4.0-1"
+version = "0.4.1-1"
 
 source = {
   url = "git://github.com/Kong/kong-plugin-prometheus",
-  tag = "0.4.0"
+  tag = "0.4.1"
 }
 
 supported_platforms = {"linux", "macosx"}

--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -6,6 +6,9 @@ local kong = kong
 local timer_at = ngx.timer.at
 
 
+prometheus.init()
+
+
 local function log(premature, message)
   if premature then
     return
@@ -19,11 +22,6 @@ local PrometheusHandler = {
   PRIORITY = 13,
   VERSION  = "0.4.0",
 }
-
-
-function PrometheusHandler:new()
-  return prometheus.init()
-end
 
 
 function PrometheusHandler:log(_)

--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -20,7 +20,7 @@ end
 
 local PrometheusHandler = {
   PRIORITY = 13,
-  VERSION  = "0.4.0",
+  VERSION  = "0.4.1",
 }
 
 


### PR DESCRIPTION
`:new` is no longer available as this plugin no longer inherits from the
BasePlugin class. This commit updates the handler so it uses the
`:init_worker` method instead to initialize its shared dictionary.