### PR TITLE
perf(*) remove unnecessary timer since no yield needed

### DIFF
--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -9,15 +9,6 @@ local timer_at = ngx.timer.at
 prometheus.init()
 
 
-local function log(premature, message)
-  if premature then
-    return
-  end
-
-  prometheus.log(message)
-end
-
-
 local PrometheusHandler = {
   PRIORITY = 13,
   VERSION  = "0.4.1",
@@ -26,10 +17,7 @@ local PrometheusHandler = {
 
 function PrometheusHandler:log(_)
   local message = basic_serializer.serialize(ngx)
-  local ok, err = timer_at(0, log, message)
-  if not ok then
-    kong.log.err("failed to create timer: ", err)
-  end
+  prometheus.log(message)
 end
 
 


### PR DESCRIPTION
The Prometheus plugin is primarily maintaining the shdict and doesn't need any yield operations. This PR removed the unnecessary timer for getting the low hanging fruit for us.

Did a couple of rounds trivial benchmarking in our cloud environment (Thanks @fffonion):

 _Noticed that P99 long tail has been dropped significantly._

*Before*

```
wrk -t 100 -c 100 --latency -d 60 http://206.189.221.120:8000
Running 1m test @ http://206.189.221.120:8000
  100 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    28.58ms   47.74ms 731.95ms   91.52%
    Req/Sec    64.04     22.94   212.00     68.01%
  Latency Distribution
     50%   14.16ms
     75%   19.08ms
     90%   48.51ms
     99%  227.18ms
  361064 requests in 1.00m, 3.92GB read
Requests/sec:   6008.43
Transfer/sec:     66.79MB
```

*After*

```
wrk -t 100 -c 100 --latency -d 60 http://206.189.221.120:8000
Running 1m test @ http://206.189.221.120:8000
  100 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    17.24ms    6.77ms 271.26ms   88.85%
    Req/Sec    58.67     14.85   262.00     77.89%
  Latency Distribution
     50%   15.84ms
     75%   18.42ms
     90%   23.05ms
     99%   38.59ms
  351932 requests in 1.00m, 3.82GB read
Requests/sec:   5857.10
Transfer/sec:     65.11MB
```

Will keep optimizing and benchmarking it further.