### PR TITLE
docs(changelog): add missing log for 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 - Tests to ensure gRPC compatibility have been added.
   [#57](https://github.com/Kong/kong-plugin-prometheus/pull/57)
 
+##  [0.4.1] - 2019/08/01
+
+- Fix issue where the plugin's shared dictionary would not be properly
+initialized
+
 ##  [0.4.0] - 2019/06/05
 
 - Remove BasePlugin inheritance (not needed anymore)


### PR DESCRIPTION
This missing log was removed in this commit : https://github.com/Kong/kong-plugin-prometheus/commit/33c0952707a3160e57c138df2e05e6bb6fc27536#diff-4ac32a78649ca5bdd8e0ba38b7006a1eL13