### PR TITLE
feat(handler) expose dataplane status on control plane

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -105,19 +105,17 @@ local function init()
   end
 
   -- Hybrid mode status
-  if kong.version_num >= 2000000 then -- 200.00.00 -> 2.0.0 then
-    if kong.configuration.role == "control_plane" then
-      cp_metrics = true
+  if kong.configuration.role == "control_plane" then
+    cp_metrics = true
 
-      clustering = require("kong.clustering")
+    clustering = require("kong.clustering")
 
-      metrics.dataplane_last_seen = prometheus:gauge("dataplane_last_seen",
-                                                "Last time data plane contacted control plane",
-                                                {"node_id", "hostname", "ip"})
-      metrics.dataplane_config_hash = prometheus:gauge("dataplane_config_hash",
-                                                "Config hash numeric value of the data plane",
-                                                {"node_id", "hostname", "ip"})
-    end
+    metrics.dataplane_last_seen = prometheus:gauge("dataplane_last_seen",
+                                              "Last time data plane contacted control plane",
+                                              {"node_id", "hostname", "ip"})
+    metrics.dataplane_config_hash = prometheus:gauge("dataplane_config_hash",
+                                              "Config hash numeric value of the data plane",
+                                              {"node_id", "hostname", "ip"})
   end
 end
 
@@ -367,8 +365,7 @@ local function metric_data()
       local labels = { node_id, status.hostname, status.ip }
       metrics.dataplane_last_seen:set(status.last_seen, labels)
       -- Note the following will be represented as a float instead of int64 since luajit
-      -- don't like int64.
-      -- But prometheus uses float instead of int64 as well
+      -- don't like int64. Good news is prometheus uses float instead of int64 as well
       metrics.dataplane_config_hash:set(tonumber("0x" .. status.config_hash), labels)
     end
   end

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -19,9 +19,6 @@ local metrics = {}
 -- prometheus.lua instance
 local prometheus
 
--- the clustering module, lazily imported
-local clustering
-
 -- use the same counter library shipped with Kong
 package.loaded['prometheus_resty_counter'] = require("resty.counter")
 
@@ -110,8 +107,6 @@ local function init()
 
   -- Hybrid mode status
   if role == "control_plane" then
-    clustering = require("kong.clustering")
-
     metrics.data_plane_last_seen = prometheus:gauge("data_plane_last_seen",
                                               "Last time data plane contacted control plane",
                                               {"node_id", "hostname", "ip"})

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -6,6 +6,8 @@ local concat = table.concat
 local select = select
 local balancer = require("kong.runloop.balancer")
 
+local CLUSTERING_SYNC_STATUS = require("kong.constants").CLUSTERING_SYNC_STATUS
+
 local stream_available, stream_api = pcall(require, "kong.tools.stream_api")
 
 local DEFAULT_BUCKETS = { 1, 2, 5, 7, 10, 15, 20, 25, 30, 40, 50, 60, 70,
@@ -15,8 +17,8 @@ local metrics = {}
 -- prometheus.lua instance
 local prometheus
 
--- the clustering and declarative module, lazily imported
-local clustering, declarative
+-- the clustering module, lazily imported
+local clustering
 local cp_metrics
 
 -- use the same counter library shipped with Kong
@@ -105,14 +107,6 @@ local function init()
   end
 
 
-  -- For all generic dbless node
-  if kong.configuration.database == "off" then
-    declarative = require("kong.db.declarative")
-
-    metrics.config_current_hash = prometheus:gauge("config_current_hash",
-                                                        "Current config hash numeric value for this node")
-  end
-
   local role = kong.configuration.role
   -- Hybrid mode status
   if role == "control_plane" then
@@ -120,12 +114,16 @@ local function init()
 
     clustering = require("kong.clustering")
 
-    metrics.dataplane_last_seen = prometheus:gauge("dataplane_last_seen",
+    metrics.data_plane_last_seen = prometheus:gauge("data_plane_last_seen",
                                               "Last time data plane contacted control plane",
                                               {"node_id", "hostname", "ip"})
-    metrics.dataplane_config_hash = prometheus:gauge("dataplane_config_hash",
+    metrics.data_plane_config_hash = prometheus:gauge("data_plane_config_hash",
                                               "Config hash numeric value of the data plane",
                                               {"node_id", "hostname", "ip"})
+
+    metrics.data_plane_version_compatible = prometheus:gauge("data_plane_version_compatible",
+                                              "Version compatible status of the data plane, 0 is incompatible",
+                                              {"node_id", "hostname", "ip", "kong_version"})
   end
 end
 
@@ -370,25 +368,35 @@ local function metric_data()
     enterprise.metric_data()
   end
 
-  if metrics.config_current_hash then
-    local current_hash = declarative.get_current_hash()
-    -- current_hash is true if it's load from file
-    if current_hash and current_hash ~= true then
-      metrics.config_current_hash:set(config_hash_to_number(current_hash))
-    end
-  end
-
   -- Hybrid mode status
   if cp_metrics then
     -- Cleanup old metrics
-    metrics.dataplane_last_seen:reset()
-    metrics.dataplane_config_hash:reset()
+    metrics.data_plane_last_seen:reset()
+    metrics.data_plane_config_hash:reset()
 
-    local data_planes = clustering.get_status()
-    for node_id, status in pairs(data_planes) do
-      local labels = { node_id, status.hostname, status.ip }
-      metrics.dataplane_last_seen:set(status.last_seen, labels)
-      metrics.dataplane_config_hash:set(config_hash_to_number(status.config_hash), labels)
+    for data_plane, err in kong.db.clustering_data_planes:each() do
+      if err then
+        kong.log.err("failed to list data planes: ", err)
+        goto next_data_plane
+      end
+
+      local labels = { data_plane.id, data_plane.hostname, data_plane.ip }
+
+      metrics.data_plane_last_seen:set(data_plane.last_seen, labels)
+      metrics.data_plane_config_hash:set(config_hash_to_number(data_plane.config_hash), labels)
+
+      labels[4] = data_plane.version
+      local compatible = 1
+
+      if data_plane.sync_status == CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE
+        or data_plane.sync_status == CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
+        or data_plane.sync_status == CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE then
+
+        compatible = 0
+      end
+      metrics.data_plane_version_compatible:set(compatible, labels)
+
+::next_data_plane::
     end
   end
 


### PR DESCRIPTION
This PR adds a series of metrics to expose connected Data Plane metrics on Control Plane
side.

sample output
```
curl -s localhost:8001/metrics|grep data_plane
# HELP kong_data_plane_config_hash Config hash value of the data plane
# TYPE kong_data_plane_config_hash gauge
kong_data_plane_config_hash{node_id="d4e7584e-b2f2-415b-bb68-3b0936f1fde3",hostname="ubuntu-bionic",ip="127.0.0.1"} 1.7158931820287e+38
# HELP kong_data_plane_last_seen Last time data plane contacted control plane
# TYPE kong_data_plane_last_seen gauge
kong_data_plane_last_seen{node_id="d4e7584e-b2f2-415b-bb68-3b0936f1fde3",hostname="ubuntu-bionic",ip="127.0.0.1"} 1600190275
# HELP kong_data_plane_version_compatible Version compatible status of the data plane, 0 is incompatible
# TYPE kong_data_plane_version_compatible gauge
kong_data_plane_version_compatible{node_id="d4e7584e-b2f2-415b-bb68-3b0936f1fde3",hostname="ubuntu-bionic",ip="127.0.0.1",kong_version="2.4.1"} 1
```