### PR TITLE
Handle stream metrics

### DIFF
--- a/kong/plugins/prometheus/api.lua
+++ b/kong/plugins/prometheus/api.lua
@@ -1,20 +1,11 @@
 local prometheus = require "kong.plugins.prometheus.exporter"
-local stream_available, stream_api = pcall(require, "kong.tools.stream_api")
 
 return {
   ["/metrics"] = {
     GET = function()
-      ngx.header.content_type = "text/plain; charset=UTF-8"
-
-      ngx.print(prometheus:collect())
-
-      if stream_available then
-        ngx.print(stream_api.request("prometheus", ""))
-      end
+      prometheus.collect()
     end,
   },
 
-  _stream = stream_available and function()
-    return prometheus:collect()
-  end or nil,
+  _stream = ngx.config.subsystem == "stream" and prometheus.metric_data or nil,
 }

--- a/kong/plugins/prometheus/api.lua
+++ b/kong/plugins/prometheus/api.lua
@@ -1,39 +1,20 @@
 local prometheus = require "kong.plugins.prometheus.exporter"
+local stream_available, stream_api = pcall(require, "kong.tools.stream_api")
 
-if ngx.config.subsystem == "stream" then
-  local stream_api = require "kong.tools.stream_api"
+return {
+  ["/metrics"] = {
+    GET = function()
+      ngx.header.content_type = "text/plain; charset=UTF-8"
 
-  stream_api.register_endpoint("/stream-metrics", function(req)
-    req:get_headers()
-    return req:response(200, { ["Content-Type"] = "text/plain; charset=UTF-8" },
-            prometheus:collect())
-  end)
+      ngx.print(prometheus:collect())
 
-else
-  local resty_http = require "resty.http"
-  local STREAM_API_PORT = 8086    -- TODO: get from config
+      if stream_available then
+        ngx.print(stream_api.request("prometheus", ""))
+      end
+    end,
+  },
 
-  local function pull_from_stream()
-    local httpc = resty_http.new()
-    assert(httpc:connect("localhost", STREAM_API_PORT))
-
-    local res = assert(httpc:request({ method = "GET", path="/stream-metrics" }))
-    local body = res:read_body()
-
-    httpc:set_keepalive(false)
-
-    return body
-  end
-
-
-  return {
-    ["/metrics"] = {
-      GET = function()
-        ngx.header.content_type = "text/plain; charset=UTF-8"
-
-        ngx.say(prometheus:collect())
-        ngx.say(pull_from_stream())
-      end,
-    },
-  }
-end
+  _stream = stream_available and function()
+    return prometheus:collect()
+  end or nil,
+}

--- a/kong/plugins/prometheus/api.lua
+++ b/kong/plugins/prometheus/api.lua
@@ -1,9 +1,39 @@
 local prometheus = require "kong.plugins.prometheus.exporter"
 
-return {
-  ["/metrics"] = {
-    GET = function()
-      prometheus.collect()
-    end,
-  },
-}
+if ngx.config.subsystem == "stream" then
+  local stream_api = require "kong.tools.stream_api"
+
+  stream_api.register_endpoint("/stream-metrics", function(req)
+    req:get_headers()
+    return req:response(200, { ["Content-Type"] = "text/plain; charset=UTF-8" },
+            prometheus:collect())
+  end)
+
+else
+  local resty_http = require "resty.http"
+  local STREAM_API_PORT = 8086    -- TODO: get from config
+
+  local function pull_from_stream()
+    local httpc = resty_http.new()
+    assert(httpc:connect("localhost", STREAM_API_PORT))
+
+    local res = assert(httpc:request({ method = "GET", path="/stream-metrics" }))
+    local body = res:read_body()
+
+    httpc:set_keepalive(false)
+
+    return body
+  end
+
+
+  return {
+    ["/metrics"] = {
+      GET = function()
+        ngx.header.content_type = "text/plain; charset=UTF-8"
+
+        ngx.say(prometheus:collect())
+        ngx.say(pull_from_stream())
+      end,
+    },
+  }
+end

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -98,60 +98,117 @@ local function set_healthiness_metrics(table, upstream, target, address, status,
   end
 end
 
-local function log(message)
-  if not metrics then
-    kong.log.err("prometheus: can not log metrics because of an initialization "
-                 .. "error, please make sure that you've declared "
-                 .. "'prometheus_metrics' shared dict in your nginx template")
-    return
+
+local log
+
+if ngx.config.subsystem == "http" then
+  function log(message)
+    if not metrics then
+      kong.log.err("prometheus: can not log metrics because of an initialization "
+              .. "error, please make sure that you've declared "
+              .. "'prometheus_metrics' shared dict in your nginx template")
+      return
+    end
+
+    local service_name
+    if message and message.service then
+      service_name = message.service.name or message.service.host
+    else
+      -- do not record any stats if the service is not present
+      return
+    end
+
+    local route_name
+    if message and message.route then
+      route_name = message.route.name or message.route.id
+    end
+
+    labels_table[1] = service_name
+    labels_table[2] = route_name
+    labels_table[3] = message.response.status
+    metrics.status:inc(1, labels_table)
+
+    local request_size = tonumber(message.request.size)
+    if request_size and request_size > 0 then
+      labels_table[3] = "ingress"
+      metrics.bandwidth:inc(request_size, labels_table)
+    end
+
+    local response_size = tonumber(message.response.size)
+    if response_size and response_size > 0 then
+      labels_table[3] = "egress"
+      metrics.bandwidth:inc(response_size, labels_table)
+    end
+
+    local request_latency = message.latencies.request
+    if request_latency and request_latency >= 0 then
+      labels_table[3] = "request"
+      metrics.latency:observe(request_latency, labels_table)
+    end
+
+    local upstream_latency = message.latencies.proxy
+    if upstream_latency ~= nil and upstream_latency >= 0 then
+      labels_table[3] = "upstream"
+      metrics.latency:observe(upstream_latency, labels_table)
+    end
+
+    local kong_proxy_latency = message.latencies.kong
+    if kong_proxy_latency ~= nil and kong_proxy_latency >= 0 then
+      labels_table[3] = "kong"
+      metrics.latency:observe(kong_proxy_latency, labels_table)
+    end
   end
 
-  local service_name
-  if message and message.service then
-    service_name = message.service.name or message.service.host
-  else
-    -- do not record any stats if the service is not present
-    return
-  end
+else
+  function log(message)
+    if not metrics then
+      kong.log.err("prometheus: can not log metrics because of an initialization "
+              .. "error, please make sure that you've declared "
+              .. "'prometheus_metrics' shared dict in your nginx template")
+      return
+    end
 
-  local route_name
-  if message and message.route then
-    route_name = message.route.name or message.route.id
-  end
+    local service_name
+    if message and message.service then
+      service_name = message.service.name or message.service.host
+    else
+      -- do not record any stats if the service is not present
+      return
+    end
 
-  labels_table[1] = service_name
-  labels_table[2] = route_name
-  labels_table[3] = message.response.status
-  metrics.status:inc(1, labels_table)
+    local route_name
+    if message and message.route then
+      route_name = message.route.name or message.route.id
+    end
 
-  local request_size = tonumber(message.request.size)
-  if request_size and request_size > 0 then
-    labels_table[3] = "ingress"
-    metrics.bandwidth:inc(request_size, labels_table)
-  end
+    labels_table[1] = service_name
+    labels_table[2] = route_name
+    labels_table[3] = message.session.status
+    metrics.status:inc(1, labels_table)
 
-  local response_size = tonumber(message.response.size)
-  if response_size and response_size > 0 then
-    labels_table[3] = "egress"
-    metrics.bandwidth:inc(response_size, labels_table)
-  end
+    local ingress_size = tonumber(message.session.received)
+    if ingress_size and ingress_size > 0 then
+      labels_table[3] = "ingress"
+      metrics.bandwidth:inc(ingress_size, labels_table)
+    end
 
-  local request_latency = message.latencies.request
-  if request_latency and request_latency >= 0 then
-    labels_table[3] = "request"
-    metrics.latency:observe(request_latency, labels_table)
-  end
+    local egress_size = tonumber(message.session.sent)
+    if egress_size and egress_size > 0 then
+      labels_table[3] = "egress"
+      metrics.bandwidth:inc(egress_size, labels_table)
+    end
 
-  local upstream_latency = message.latencies.proxy
-  if upstream_latency ~= nil and upstream_latency >= 0 then
-    labels_table[3] = "upstream"
-    metrics.latency:observe(upstream_latency, labels_table)
-  end
+    local session_latency = message.latencies.session
+    if session_latency and session_latency >= 0 then
+      labels_table[3] = "request"
+      metrics.latency:observe(session_latency, labels_table)
+    end
 
-  local kong_proxy_latency = message.latencies.kong
-  if kong_proxy_latency ~= nil and kong_proxy_latency >= 0 then
-    labels_table[3] = "kong"
-    metrics.latency:observe(kong_proxy_latency, labels_table)
+    local kong_proxy_latency = message.latencies.kong
+    if kong_proxy_latency ~= nil and kong_proxy_latency >= 0 then
+      labels_table[3] = "kong"
+      metrics.latency:observe(kong_proxy_latency, labels_table)
+    end
   end
 end
 
@@ -236,7 +293,7 @@ local function collect()
                                         {res.workers_lua_vms[i].pid})
   end
 
-  prometheus:collect()
+  return prometheus:metric_data()
 end
 
 local function get_prometheus()

--- a/kong/plugins/prometheus/serve.lua
+++ b/kong/plugins/prometheus/serve.lua
@@ -1,8 +1,6 @@
 local lapis = require "lapis"
 local prometheus = require "kong.plugins.prometheus.exporter"
 
-local stream_available, stream_api = pcall(require, "kong.tools.stream_api")
-
 
 local kong = kong
 
@@ -39,13 +37,7 @@ end)
 
 
 app:match("/metrics", function()
-  ngx.header.content_type = "text/plain; charset=UTF-8"
-
-  ngx.print(prometheus:collect())
-
-  if stream_available then
-    ngx.print(stream_api.request("prometheus", "") or "")
-  end
+  prometheus:collect()
 end)
 
 

--- a/kong/plugins/prometheus/serve.lua
+++ b/kong/plugins/prometheus/serve.lua
@@ -1,6 +1,8 @@
 local lapis = require "lapis"
 local prometheus = require "kong.plugins.prometheus.exporter"
 
+local stream_available, stream_api = pcall(require, "kong.tools.stream_api")
+
 
 local kong = kong
 
@@ -37,7 +39,13 @@ end)
 
 
 app:match("/metrics", function()
-  prometheus:collect()
+  ngx.header.content_type = "text/plain; charset=UTF-8"
+
+  ngx.print(prometheus:collect())
+
+  if stream_available then
+    ngx.print(stream_api.request("prometheus", "") or "")
+  end
 end)
 
 


### PR DESCRIPTION
Same idea as #44: add an internal endpoint to expose the streaming module metrics.
"public" endpoint pulls from the other one, to avoid user-visible change.

Requires the ~~"streaming api" feature of Kong/kong#6374~~ inter-module RPC feature of Kong/kong#6552
