### PR TITLE
feat(exporter) add url location and GET param counters, with regex extract

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ kong_http_consumer_status{service="upstream",route="default",code="200",consumer
 # HELP kong_http_status HTTP status codes per service in Kong
 # TYPE kong_http_status counter
 kong_http_status{code="301",service="google"} 2
+# HELP kong_http_url_location_consumer_total HTTP status codes for specific URL location in Kong
+# TYPE kong_http_url_location_consumer_total counter
+kong_http_url_location_consumer_total{service="upstream",route="default",location="hello",consumer="consumer1"} 5
+# HELP kong_http_url_param_consumer_total HTTP status codes for specific GET param in Kong
+# TYPE kong_http_url_param_consumer_total counter
+kong_http_url_param_consumer_total{service="upstream",route="default",param="123456",consumer="consumer1"} 5
 # HELP kong_latency Latency added by Kong, total request time and upstream latency for each service in Kong
 # TYPE kong_latency histogram
 kong_latency_bucket{type="kong",service="google",le="00001.0"} 1

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ kong_bandwidth{type="ingress",service="google"} 254
 # HELP kong_datastore_reachable Datastore reachable from Kong, 0 is unreachable
 # TYPE kong_datastore_reachable gauge
 kong_datastore_reachable 1
+# HELP kong_http_consumer_status HTTP status codes for customer per service/route in Kong
+# TYPE kong_http_consumer_status counter
+kong_http_consumer_status{service="upstream",route="default",code="200",consumer="consumer1"} 5185
 # HELP kong_http_status HTTP status codes per service in Kong
 # TYPE kong_http_status counter
 kong_http_status{code="301",service="google"} 2

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -79,6 +79,10 @@ local function init()
                                          "Total bandwidth in bytes " ..
                                          "consumed per service/route in Kong",
                                          {"service", "route", "type"})
+  metrics.consumer_status = prometheus:counter("http_consumer_status",
+                                          "HTTP status codes for customer per service/route in Kong",
+                                          {"service", "route", "code", "consumer"})
+
   if enterprise then
     enterprise.init(prometheus)
   end
@@ -92,6 +96,7 @@ end
 -- Since in the prometheus library we create a new table for each diverged label
 -- so putting the "more dynamic" label at the end will save us some memory
 local labels_table = {0, 0, 0}
+local labels_table4 = {0, 0, 0, 0}
 local upstream_target_addr_health_table = {
   { value = 0, labels = { 0, 0, 0, "healthchecks_off" } },
   { value = 0, labels = { 0, 0, 0, "healthy" } },
@@ -113,7 +118,7 @@ end
 local log
 
 if ngx.config.subsystem == "http" then
-  function log(message)
+  function log(message, serialized)
     if not metrics then
       kong.log.err("prometheus: can not log metrics because of an initialization "
               .. "error, please make sure that you've declared "
@@ -167,6 +172,14 @@ if ngx.config.subsystem == "http" then
     if kong_proxy_latency ~= nil and kong_proxy_latency >= 0 then
       labels_table[3] = "kong"
       metrics.latency:observe(kong_proxy_latency, labels_table)
+    end
+
+    if serialized.consumer ~= nil then
+      labels_table4[1] = labels_table[1]
+      labels_table4[2] = labels_table[2]
+      labels_table4[3] = message.response.status
+      labels_table4[4] = serialized.consumer
+      metrics.consumer_status:inc(1, labels_table4)
     end
   end
 

--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -15,9 +15,15 @@ function PrometheusHandler.init_worker()
 end
 
 
-function PrometheusHandler.log()
+function PrometheusHandler.log(self, conf)
   local message = kong.log.serialize()
-  prometheus.log(message)
+
+  local serialized = {}
+  if conf.per_consumer and message.consumer ~= nil then
+    serialized.consumer = message.consumer.username
+  end
+
+  prometheus.log(message, serialized)
 end
 
 

--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -18,7 +18,12 @@ end
 function PrometheusHandler.log(self, conf)
   local message = kong.log.serialize()
 
-  local serialized = {}
+  local serialized = {
+    param_list = conf.param_collect_list,
+    param_extract = conf.param_value_extract,
+    location = conf.location_collect,
+    location_extract = conf.location_extract,
+  }
   if conf.per_consumer and message.consumer ~= nil then
     serialized.consumer = message.consumer.username
   end

--- a/kong/plugins/prometheus/schema.lua
+++ b/kong/plugins/prometheus/schema.lua
@@ -12,7 +12,9 @@ return {
   fields = {
     { config = {
         type = "record",
-        fields = {},
+        fields = {
+          { per_consumer = { type = "boolean", default = false }, },
+        },
         custom_validator = validate_shared_dict,
     }, },
   },

--- a/kong/plugins/prometheus/schema.lua
+++ b/kong/plugins/prometheus/schema.lua
@@ -13,6 +13,10 @@ return {
     { config = {
         type = "record",
         fields = {
+          { param_collect_list = { type = "array", elements = { type = "string", match = "^[a-z_]+$" }, }, },
+          { param_value_extract  = { type = "string" }, },	-- regex
+          { location_collect = { type = "boolean", default = false }, },
+          { location_extract = { type = "string" }, },	-- regex
           { per_consumer = { type = "boolean", default = false }, },
         },
         custom_validator = validate_shared_dict,


### PR DESCRIPTION
Hello,
this is a second revamp of pull request #113, implementing poor man`s alternative for URL endpoint usage tracking.

New features:
   * per-url param metric
      * collects hits per first defined url param from `param_collect_list`, attaching its value as `param` label
      * creates `kong_http_url_param_total` or `kong_http_url_param_consumer_total` depending on `per_consumer` switch
      * optionally extracts/validates param label value according to `param_value_extract` regexp, (to avoid possible problems with metric cardinality)

  * per-url location metric
      * collects hits per ngx.var.uri ($uri) location, attaching its value as `location` label
      * creates `kong_http_url_location_total` or `kong_http_url_location_consumer_total` depending on `per_consumer` switch
      * optionally extracts/validates location label value according to `location_extract` regexp

These new metrics make sense especially for people that don't want to setup/run/maintain additional log-collection/extraction system (like fluentd/splunk) or implement any other kind of instrumentation systems. With this, they can still have at least a basic insight about per-consumer usage of their services identified by URL param and/or URL location (part).

Ideally, this features should be used together with consumer authentication (as it is in our use case), to further reduce possible metrics overpopulation problems.

Thank you
