### PR TITLE
fix(*) make plugin impervious to underscore changes

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -339,7 +339,7 @@ local function metric_data()
 end
 
 local function collect(with_stream)
-  ngx.header.content_type = "text/plain; charset=UTF-8"
+  ngx.header["Content-Type"] = "text/plain; charset=UTF-8"
 
   ngx.print(metric_data())
 

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -662,7 +662,7 @@ end
 -- It will get the metrics from the dictionary, sort them, and expose them
 -- aling with TYPE and HELP comments.
 function Prometheus:collect()
-  ngx.header.content_type = "text/plain"
+  ngx.header["Content-Type"] = "text/plain"
   ngx.print(self:metric_data())
 end
 


### PR DESCRIPTION
This change makes the code impervious to setting `lua_transform_underscores_in_response_headers` to `off`.

Related with Kong/kong#6995