### PR TITLE
feat(prometheus) sync upstream changes for vendored prometheus library

### DIFF
--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -609,9 +609,10 @@ end
 -- Returns:
 --   an object that should be used to register metrics.
 function Prometheus.init(dict_name, options_or_prefix)
-  if ngx.get_phase() ~= 'init' and ngx.get_phase() ~= 'init_worker' then
+  if ngx.get_phase() ~= 'init' and ngx.get_phase() ~= 'init_worker' and
+      ngx.get_phase() ~= 'timer' then
     error('Prometheus.init can only be called from ' ..
-      'init_by_lua_block or init_worker_by_lua_block', 2)
+      'init_by_lua_block, init_worker_by_lua_block or timer' , 2)
   end
 
   local self = setmetatable({}, mt)


### PR DESCRIPTION
Changelog from upstream
```
ab14b2f3fd23d85cf032aab6b407aadc6b45cf1b Do not trim trailing .0 from bucket label values
9a03008849e09cd86fed86ac0771f959b6874347 feat: remove leading and trailing zeros in bucket label values (#119)
18124f16445369106386fb0d47c1e96c53fc0ed5 feat: histogram support reset (#114)
baeae794c5b21099e2b2c4750ba794bb41a5e26d Tidy up utf8-related comments and tests
1b6137c6df094c3f755dc91ec9ba3be24b4c40ca Allow utf8 label values (#110)
97ba6cd0fc31b7f6c9d3f2bdc5514a966cbdd23d reset() should not log an error if metric value is not found (#106)
e2cb2af8ed6cc61a339c473f498d32f7fd47a96d Simplify library initialization (#94)
d45dddbb227d3decf8029332428ee4fcf5b0aefc Configurable name for the error metric (#91)
27bae6aae0cbdd9bf30de5d189dee76672659ee4 fix duplicate metric check (#89)

```

Backports are done in https://github.com/Kong/lua-resty-prometheus where one change that is removed due
to debatable tradeoff between complexity and performance. To view what's different from upstream, please use
this link https://github.com/Kong/lua-resty-prometheus/compare/upstream/master...Kong:test.